### PR TITLE
Fix for unicode issues

### DIFF
--- a/examples/SimpleXML.java
+++ b/examples/SimpleXML.java
@@ -39,7 +39,7 @@ public final class SimpleXML extends DSL
             if (!child.parse(parse))
                 return false;
 
-            String close_tag = parse.string.substring(pos0, parse.pos);
+            String close_tag = parse.substring(pos0, parse.pos);
             ArrayDeque<String> tstack = tag_stack.data(parse);
             String open_tag = tstack.peek();
 

--- a/examples/norswap/lang/java/Grammar.java
+++ b/examples/norswap/lang/java/Grammar.java
@@ -729,7 +729,7 @@ public final class Grammar extends DSL
         seq(SEMI, class_body_decl.at_least(0)).opt();
 
     public rule enum_constants =
-        enum_constant.sep(1, COMMA).opt();
+        enum_constant.sep_trailing(1, COMMA).opt();
 
     public rule enum_body =
         seq(LBRACE, enum_constants, enum_class_decls, RBRACE)
@@ -851,7 +851,7 @@ public final class Grammar extends DSL
         .push(xs -> TryResource.mk($(xs,0), $(xs,1), $(xs,2), $(xs,3)));
 
     public rule resources =
-        seq(LPAREN, resource.sep(1, SEMI), RPAREN).opt()
+        seq(LPAREN, resource.sep_trailing(1, SEMI), RPAREN).opt()
         .collect().as_list(TryResource.class);
 
     public rule try_stmt =

--- a/examples/norswap/lang/java/LexUtils.java
+++ b/examples/norswap/lang/java/LexUtils.java
@@ -159,7 +159,7 @@ public final class LexUtils
     /**
      * Returns the integer value of the given decimal or hexadecimal digit.
      */
-    public static int digit (char c)
+    public static int digit (int c)
     {
         if ('0' <= c && c <= '9' )
             return c - '0';
@@ -177,7 +177,7 @@ public final class LexUtils
      * Returns true iff {@code c} is a valid hexadecimal digit (for letters, both lower and upper
      * case are accepted).
      */
-    public static boolean is_hex_digit (char c)
+    public static boolean is_hex_digit (int c)
     {
         return '0' <= c && c <= '9'
             || 'a' <= c && c <= 'f'
@@ -189,7 +189,7 @@ public final class LexUtils
     /**
      * Returns true iff {@code c} is a valid octal digit.
      */
-    public static boolean is_octal_digit (char c)
+    public static boolean is_octal_digit (int c)
     {
         return '0' <= c && c <= '7';
     }

--- a/src/norswap/autumn/DSL.java
+++ b/src/norswap/autumn/DSL.java
@@ -400,7 +400,7 @@ public class DSL
     /**
      * A {@link CharPredicate} that matches a single character.
      */
-    public rule character (char character) {
+    public rule character (int character) {
         return new rule(CharPredicate.single(character));
     }
 
@@ -409,7 +409,7 @@ public class DSL
     /**
      * Returns a {@link CharPredicate} parser that matches an (inclusive) range of characters.
      */
-    public rule range (char start, char end) {
+    public rule range (int start, int end) {
         return new rule(CharPredicate.range(start, end));
     }
 
@@ -427,7 +427,7 @@ public class DSL
     /**
      * Returns a {@link CharPredicate} parser that matches a set of characters.
      */
-    public rule set (char... chars) {
+    public rule set (int... chars) {
         return new rule(CharPredicate.set(chars));
     }
 

--- a/src/norswap/autumn/Parse.java
+++ b/src/norswap/autumn/Parse.java
@@ -336,6 +336,23 @@ public final class Parse
         return candidate.codePoints().sequential().allMatch((c) -> it.hasNext() && c == it.next());
     }
 
+    /**
+     * Returns true if the given string candidate appears in the parse's input string at the given
+     * index. This function is safe even if the string candidate is longer than the remaining input.
+     */
+    public boolean match (int index, int[] candidate)
+    {
+        assert string != null;
+
+        if(index + candidate.length > string.length)
+        	return false;
+        for(int i = 0; i < candidate.length; i++)
+        	if(string[index + i] != candidate[i])
+        		return false;
+        
+        return true;
+    }
+
 	/**
 	 * Constructs a substring of the parser's input.
 	 * 

--- a/src/norswap/autumn/StackAction.java
+++ b/src/norswap/autumn/StackAction.java
@@ -87,7 +87,7 @@ public interface StackAction
         @Override default void apply (Parse parse, Object[] items, int pos0, int size0)
         {
             assert parse.string != null;
-            apply(parse, items, items != null ? parse.string.substring(pos0, parse.pos) : null);
+            apply(parse, items, items != null ? new String(parse.string, pos0, parse.pos - pos0) : null);
         }
 
         /**
@@ -179,7 +179,7 @@ public interface StackAction
     {
         @Override default void apply (Parse parse, Object[] items, int pos0, int size0)
         {
-            String match = items != null ? parse.string.substring(pos0, parse.pos) : null;
+            String match = items != null ? new String(parse.string, pos0, parse.pos - pos0) : null;
             parse.stack.push(get(parse, items, match));
         }
 

--- a/src/norswap/autumn/parsers/CharPredicate.java
+++ b/src/norswap/autumn/parsers/CharPredicate.java
@@ -4,6 +4,8 @@ import norswap.autumn.DSL;
 import norswap.autumn.Parse;
 import norswap.autumn.Parser;
 import norswap.autumn.ParserVisitor;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.IntPredicate;
 
@@ -91,7 +93,7 @@ public final class CharPredicate extends Parser
     /**
      * Creates a new parser that matches a single {@code c} character.
      */
-    public static CharPredicate single (char c)
+    public static CharPredicate single (int c)
     {
         return new CharPredicate("[" + escape_quoted_section("" + c) + "]", it -> it == c);
     }
@@ -101,7 +103,7 @@ public final class CharPredicate extends Parser
     /**
      * Creates a new parser that matches a single character in the [start-end] range.
      */
-    public static CharPredicate range (char start, char end)
+    public static CharPredicate range (int start, int end)
     {
         String str = escape_quoted_section(start + "-" + end);
         return new CharPredicate("[" + str + "]", it ->
@@ -116,7 +118,7 @@ public final class CharPredicate extends Parser
     public static CharPredicate set (String chars)
     {
         return new CharPredicate("[" + escape_quoted_section(chars) + "]", it ->
-            chars.indexOf(it) >= 0);
+            chars.indexOf(it) >= 0); // indexOf also works with code points
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -124,9 +126,12 @@ public final class CharPredicate extends Parser
     /**
      * Creates a new parser that matches a single character contains in {@code chars}.
      */
-    public static CharPredicate set (char... chars)
+    public static CharPredicate set (int... chars)
     {
-        return set(new String(chars));
+    	String s = new String(chars, 0, chars.length);
+    	Arrays.sort(chars);
+        return new CharPredicate("[" + escape_quoted_section(s) + "]", it ->
+        Arrays.binarySearch(chars, it) >= 0);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/src/norswap/autumn/parsers/StringMatch.java
+++ b/src/norswap/autumn/parsers/StringMatch.java
@@ -17,6 +17,7 @@ public final class StringMatch extends Parser {
     // ---------------------------------------------------------------------------------------------
 
     public final String string;
+    public final int[] codepoints;
 
     // ---------------------------------------------------------------------------------------------
 
@@ -31,6 +32,7 @@ public final class StringMatch extends Parser {
      */
     public StringMatch (String string, Parser whitespace)
     {
+    	this.codepoints = string.codePoints().toArray();
         this.string = string;
         this.whitespace = whitespace;
     }
@@ -39,10 +41,10 @@ public final class StringMatch extends Parser {
 
     @Override public boolean doparse (Parse parse)
     {
-        if (!parse.match(parse.pos, string))
+        if (!parse.match(parse.pos, codepoints))
             return false;
 
-        parse.pos += string.length();
+        parse.pos += codepoints.length;
         return whitespace == null || whitespace.parse(parse);
     }
 


### PR DESCRIPTION
 * Use 32-bit characters (int) instead of Java's native char – This should avoid issues with code points in the supplementary multilingual planes (0x010000–0x10FFFF) being split across two chars.
* Also fix issue with trailing commas/semicolons in enum declarations and try-with-resources